### PR TITLE
fix: Fix failing tests - schema_version UNIQUE constraint and filename ASCII filter

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -125,9 +125,9 @@ class Database:
                 for statement in statements:
                     conn.execute(statement)
 
-                # Record migration version
+                # Record migration version (migration file may have already inserted it)
                 conn.execute(
-                    "INSERT INTO schema_version (version) VALUES (?)",
+                    "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
                     (version,)
                 )
                 conn.commit()

--- a/services/sie4_export.py
+++ b/services/sie4_export.py
@@ -508,9 +508,9 @@ class SIE4Exporter:
         
         Format: Företagsnamn_ÅÅÅÅ.si
         """
-        # Rensa företagsnamn för filnamn
+        # Rensa företagsnamn för filnamn (ASCII only)
         safe_name = "".join(
-            c for c in company_name if c.isalnum() or c in (" ", "-", "_")
+            c for c in company_name if (c.isascii() and c.isalnum()) or c in (" ", "-", "_")
         ).strip()
         safe_name = safe_name.replace(" ", "_")
         year = fiscal_year.start_date.year


### PR DESCRIPTION
- Use INSERT OR IGNORE in init_db() to handle migrations that already
  insert their own version into schema_version (migrations 1-4 do this),
  preventing UNIQUE constraint violations during test setup
- Restrict get_filename() to ASCII-only alphanumeric chars so Swedish
  letters (ö, ä, å) are stripped from filenames, matching test expectations

https://claude.ai/code/session_01CMgwzFhuAqNFB65rQmme6p