### PR TITLE
fix: Remove hardcoded API key fallback, centralize API calls (#1)

### DIFF
--- a/frontend-v3/app/reports/page.tsx
+++ b/frontend-v3/app/reports/page.tsx
@@ -40,11 +40,7 @@ export default function ReportsPage() {
     setExporting(true);
     try {
       // Find period_id for selected year/month
-      const periodsResp = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/periods`,
-        { headers: { Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}` } }
-      );
-      const periodsData = await periodsResp.json();
+      const periodsData = await api.getPeriods();
       const periods = periodsData?.periods || periodsData || [];
       
       // Find matching period
@@ -74,20 +70,15 @@ export default function ReportsPage() {
       // Try HTML endpoint first (always available), then PDF
       const htmlEndpoint = pdfEndpoint.replace(/\/([^/]+)$/, "/$1/html");
       
-      const resp = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}${pdfEndpoint}`,
-        { headers: { Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}` } }
-      );
-
-      if (resp.ok) {
-        const blob = await resp.blob();
+      try {
+        const blob = await api.getPdfExport(pdfEndpoint);
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
         a.download = `${tab}-${year}${month ? `-${String(month).padStart(2, "0")}` : ""}.pdf`;
         a.click();
         URL.revokeObjectURL(url);
-      } else {
+      } catch {
         // Fallback: open HTML version in new tab
         window.open(
           `${process.env.NEXT_PUBLIC_API_URL || ""}${htmlEndpoint}`,

--- a/frontend-v3/app/vouchers/[id]/page.tsx
+++ b/frontend-v3/app/vouchers/[id]/page.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useVoucher, useAccounts } from "@/hooks/useData";
+import { api } from "@/lib/api";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import {
   ArrowLeft,
@@ -44,34 +45,14 @@ export default function VoucherDetailPage() {
   // Audit trail
   const { data: auditData } = useQuery({
     queryKey: ["voucher-audit", id],
-    queryFn: async () => {
-      const resp = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/vouchers/${id}/audit`,
-        {
-          headers: {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}`,
-          },
-        }
-      );
-      return resp.json();
-    },
+    queryFn: () => api.getVoucherAudit(id),
     staleTime: 5 * 60 * 1000,
   });
 
   // Attachments
   const { data: attachmentsData, refetch: refetchAttachments } = useQuery({
     queryKey: ["voucher-attachments", id],
-    queryFn: async () => {
-      const resp = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/vouchers/${id}/attachments`,
-        {
-          headers: {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}`,
-          },
-        }
-      );
-      return resp.json();
-    },
+    queryFn: () => api.getVoucherAttachments(id),
     staleTime: 5 * 60 * 1000,
   });
 
@@ -94,18 +75,7 @@ export default function VoucherDetailPage() {
     async (file: globalThis.File) => {
       setUploading(true);
       try {
-        const formData = new FormData();
-        formData.append("file", file);
-        await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/vouchers/${id}/attachments`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}`,
-            },
-            body: formData,
-          }
-        );
+        await api.uploadVoucherAttachment(id, file);
         refetchAttachments();
       } catch {
         alert("Kunde inte ladda upp filen");
@@ -119,15 +89,7 @@ export default function VoucherDetailPage() {
   const handleDeleteAttachment = async (attachmentId: string) => {
     if (!confirm("Ta bort denna bilaga?")) return;
     try {
-      await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/vouchers/${id}/attachments/${attachmentId}`,
-        {
-          method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}`,
-          },
-        }
-      );
+      await api.deleteVoucherAttachment(id, attachmentId);
       refetchAttachments();
     } catch {
       alert("Kunde inte ta bort bilagan");
@@ -199,29 +161,14 @@ export default function VoucherDetailPage() {
     setSaving(true);
     setSaveResult(null);
     try {
-      await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/vouchers/${id}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production"}`,
-          },
-          body: JSON.stringify({
-            rows: editedRows.map((r: any) => ({
-              account: r.account_code || r.account,
-              debit: r.debit || 0,
-              credit: r.credit || 0,
-            })),
-            reason: correctionReason || undefined,
-            teach_ai: teachAI,
-          }),
-        }
-      ).then(async (res) => {
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          throw new Error(data.detail?.error || data.detail || "Okänt fel");
-        }
+      await api.updateVoucher(id, {
+        rows: editedRows.map((r: any) => ({
+          account: r.account_code || r.account,
+          debit: r.debit || 0,
+          credit: r.credit || 0,
+        })),
+        reason: correctionReason || undefined,
+        teach_ai: teachAI,
       });
       setSaveResult({
         ok: true,

--- a/frontend-v3/lib/api.ts
+++ b/frontend-v3/lib/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 const API_KEY =
-  process.env.NEXT_PUBLIC_API_KEY || "dev-key-change-in-production";
+  process.env.NEXT_PUBLIC_API_KEY || "";
 
 const apiClient = axios.create({
   baseURL: API_URL,
@@ -115,6 +115,34 @@ export const api = {
   },
   getVoucher: async (id: string) => {
     const { data } = await apiClient.get(`/api/v1/vouchers/${id}`);
+    return data;
+  },
+  getVoucherAudit: async (id: string) => {
+    const { data } = await apiClient.get(`/api/v1/vouchers/${id}/audit`);
+    return data;
+  },
+  getVoucherAttachments: async (id: string) => {
+    const { data } = await apiClient.get(`/api/v1/vouchers/${id}/attachments`);
+    return data;
+  },
+  uploadVoucherAttachment: async (id: string, file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const { data } = await apiClient.post(
+      `/api/v1/vouchers/${id}/attachments`,
+      formData,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return data;
+  },
+  deleteVoucherAttachment: async (voucherId: string, attachmentId: string) => {
+    const { data } = await apiClient.delete(
+      `/api/v1/vouchers/${voucherId}/attachments/${attachmentId}`
+    );
+    return data;
+  },
+  updateVoucher: async (id: string, payload: Record<string, unknown>) => {
+    const { data } = await apiClient.put(`/api/v1/vouchers/${id}`, payload);
     return data;
   },
 
@@ -247,6 +275,20 @@ export const api = {
   getFiscalYears: async () => {
     const { data } = await apiClient.get("/api/v1/fiscal-years");
     return data;
+  },
+
+  // Periods
+  getPeriods: async () => {
+    const { data } = await apiClient.get("/api/v1/periods");
+    return data;
+  },
+
+  // PDF export — returns a Blob
+  getPdfExport: async (endpoint: string): Promise<Blob> => {
+    const { data } = await apiClient.get(endpoint, {
+      responseType: "blob",
+    });
+    return data as Blob;
   },
 };
 


### PR DESCRIPTION
## Problem
Several frontend files made raw `fetch()` calls with `process.env.NEXT_PUBLIC_API_KEY` using a hardcoded fallback (`"dev-key-change-in-production"`). This API key was visible in client-bundled JavaScript.

## Changes

### `frontend-v3/lib/api.ts`
- Changed API_KEY fallback from `"dev-key-change-in-production"` to `""`
- Added missing methods:
  - `getVoucherAudit(id)` — `GET /api/v1/vouchers/:id/audit`
  - `getVoucherAttachments(id)` — `GET /api/v1/vouchers/:id/attachments`
  - `uploadVoucherAttachment(id, file)` — `POST /api/v1/vouchers/:id/attachments`
  - `deleteVoucherAttachment(voucherId, attachmentId)` — `DELETE`
  - `updateVoucher(id, payload)` — `PUT /api/v1/vouchers/:id`
  - `getPeriods()` — `GET /api/v1/periods`
  - `getPdfExport(endpoint)` — returns Blob for PDF download

### `frontend-v3/app/vouchers/[id]/page.tsx`
- Replaced 5 raw `fetch()` calls (audit, attachments, upload, delete, update) with `api.*` methods
- Removed all inline `Authorization` header construction

### `frontend-v3/app/reports/page.tsx`
- Replaced raw `fetch()` for periods lookup with `api.getPeriods()`
- Replaced raw `fetch()` for PDF export with `api.getPdfExport()`

## Result
- **0 occurrences** of `dev-key-change-in-production` remain in the codebase
- `NEXT_PUBLIC_API_KEY` is only referenced in `lib/api.ts` (with empty string fallback)
- All API calls go through the centralized Axios client

Closes #1