### PR TITLE
fix: Server-side voucher search with pagination (#7)

### DIFF
--- a/api/routes/reports.py
+++ b/api/routes/reports.py
@@ -38,7 +38,7 @@ async def get_income_statement(
     
     All amounts returned in ören (divide by 100 for kronor).
     """
-    vouchers = VoucherRepository.list_all(status="posted")
+    vouchers, _ = VoucherRepository.list_all(status="posted")
 
     # Filter by year/month
     if year:
@@ -125,7 +125,7 @@ async def get_balance_sheet(
     
     All amounts in ören.
     """
-    vouchers = VoucherRepository.list_all(status="posted")
+    vouchers, _ = VoucherRepository.list_all(status="posted")
 
     # Filter by date
     if as_of_date:
@@ -239,7 +239,7 @@ async def get_general_ledger(
     
     Returns all transactions for the account with running balance.
     """
-    vouchers = VoucherRepository.list_all(status="posted")
+    vouchers, _ = VoucherRepository.list_all(status="posted")
     
     if year:
         vouchers = [v for v in vouchers if _parse_voucher_date(v).year == year]
@@ -296,7 +296,7 @@ async def get_trial_balance(
     period: Optional[int] = Query(None),
 ):
     """Get trial balance (råbalans) showing debit/credit for all accounts."""
-    vouchers = VoucherRepository.list_all(status="posted")
+    vouchers, _ = VoucherRepository.list_all(status="posted")
 
     if year:
         vouchers = [v for v in vouchers if _parse_voucher_date(v).year == year]

--- a/api/routes/vouchers.py
+++ b/api/routes/vouchers.py
@@ -197,6 +197,9 @@ async def update_voucher(
 async def list_vouchers(
     period_id: str = Query(None, description="Filter by period ID (optional)"),
     voucher_status: str = Query("all", alias="status", description="Filter: draft, posted, or all"),
+    search: str = Query(None, description="Search in description or voucher number"),
+    limit: int = Query(None, description="Max vouchers to return (pagination)"),
+    offset: int = Query(0, description="Number of vouchers to skip (pagination)"),
     ledger: LedgerService = Depends(get_ledger_service),
 ):
     """
@@ -204,19 +207,26 @@ async def list_vouchers(
     
     Filter by status: "draft", "posted", or "all".
     If period_id is omitted, returns vouchers from all periods.
+    Supports server-side search on description and voucher number.
     """
     try:
         status_filter = voucher_status if voucher_status != "all" else None
         
         if period_id:
             vouchers = ledger.vouchers.list_for_period(period_id, status=status_filter)
+            total = len(vouchers)
         else:
-            vouchers = ledger.vouchers.list_all(status=status_filter)
+            vouchers, total = ledger.vouchers.list_all(
+                status=status_filter,
+                search=search,
+                limit=limit,
+                offset=offset,
+            )
         
         return {
             "period_id": period_id,
             "status_filter": voucher_status,
-            "total": len(vouchers),
+            "total": total,
             "vouchers": [_voucher_to_response(v) for v in vouchers]
         }
     except Exception as e:

--- a/frontend-v3/app/vouchers/page.tsx
+++ b/frontend-v3/app/vouchers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -24,28 +24,40 @@ const statusOptions = [
   { value: "posted", label: "Bokförda" },
 ];
 
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
 export default function VouchersPage() {
   const [status, setStatus] = useState("");
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
+
+  // Reset to page 0 when search term changes
+  const prevSearch = useRef(debouncedSearch);
+  useEffect(() => {
+    if (prevSearch.current !== debouncedSearch) {
+      setPage(0);
+      prevSearch.current = debouncedSearch;
+    }
+  }, [debouncedSearch]);
 
   const { data, isLoading } = useVouchers(
     status || undefined,
     PAGE_SIZE,
-    page * PAGE_SIZE
+    page * PAGE_SIZE,
+    debouncedSearch || undefined
   );
 
   const vouchers = data?.vouchers || [];
   const total = data?.total || 0;
   const totalPages = Math.ceil(total / PAGE_SIZE);
-
-  const filtered = search
-    ? vouchers.filter(
-        (v: any) =>
-          v.description?.toLowerCase().includes(search.toLowerCase()) ||
-          String(v.number).includes(search)
-      )
-    : vouchers;
 
   return (
     <div className="p-4 lg:p-8 space-y-6 max-w-[1400px] mx-auto">
@@ -101,7 +113,7 @@ export default function VouchersPage() {
                 <Skeleton key={i} className="h-12 w-full" />
               ))}
             </div>
-          ) : filtered.length > 0 ? (
+          ) : vouchers.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
@@ -127,7 +139,7 @@ export default function VouchersPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.map((v: any) => {
+                  {vouchers.map((v: any) => {
                     const totalDebit = v.rows?.reduce(
                       (s: number, r: any) => s + (r.debit || 0),
                       0

--- a/frontend-v3/hooks/useData.ts
+++ b/frontend-v3/hooks/useData.ts
@@ -3,10 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
-export function useVouchers(status?: string, limit = 15, offset = 0) {
+export function useVouchers(status?: string, limit = 15, offset = 0, search?: string) {
   return useQuery({
-    queryKey: ["vouchers", status, limit, offset],
-    queryFn: () => api.getVouchers(status, limit, offset),
+    queryKey: ["vouchers", status, limit, offset, search],
+    queryFn: () => api.getVouchers(status, limit, offset, search),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/frontend-v3/lib/api.ts
+++ b/frontend-v3/lib/api.ts
@@ -107,9 +107,9 @@ export const api = {
   },
 
   // Vouchers
-  getVouchers: async (status?: string, limit = 15, offset = 0) => {
+  getVouchers: async (status?: string, limit = 15, offset = 0, search?: string) => {
     const { data } = await apiClient.get("/api/v1/vouchers", {
-      params: { status, limit, offset },
+      params: { status, limit, offset, search: search || undefined },
     });
     return data;
   },

--- a/repositories/voucher_repo.py
+++ b/repositories/voucher_repo.py
@@ -139,24 +139,52 @@ class VoucherRepository:
         return vouchers
     
     @staticmethod
-    def list_all(status: Optional[str] = None) -> List[Voucher]:
-        """List all vouchers across all periods."""
-        sql = "SELECT id FROM vouchers"
-        params = []
-        
+    def list_all(
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> tuple[List[Voucher], int]:
+        """List all vouchers across all periods.
+
+        Returns (vouchers, total_count) to support pagination.
+        When *search* is given, filters on description (LIKE) or voucher number.
+        """
+        where_clauses = []
+        params: list = []
+
         if status:
-            sql += " WHERE status = ?"
+            where_clauses.append("status = ?")
             params.append(status)
-        
-        sql += " ORDER BY date DESC, series, number"
-        
-        cursor = db.execute(sql, tuple(params))
+
+        if search:
+            where_clauses.append(
+                "(description LIKE ? OR CAST(number AS TEXT) LIKE ?)"
+            )
+            like = f"%{search}%"
+            params.extend([like, like])
+
+        where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+        # Total count
+        count_sql = f"SELECT COUNT(*) as cnt FROM vouchers{where_sql}"
+        total = db.execute(count_sql, tuple(params)).fetchone()["cnt"]
+
+        # Fetch page
+        sql = f"SELECT id FROM vouchers{where_sql} ORDER BY date DESC, series, number"
+        page_params = list(params)
+
+        if limit is not None:
+            sql += " LIMIT ? OFFSET ?"
+            page_params.extend([limit, offset])
+
+        cursor = db.execute(sql, tuple(page_params))
         vouchers = []
         for row in cursor.fetchall():
             voucher = VoucherRepository.get(row["id"])
             if voucher:
                 vouchers.append(voucher)
-        return vouchers
+        return vouchers, total
     
     @staticmethod
     def get_next_number(series: str, fiscal_year_id: str) -> int:

--- a/services/anomaly_detection.py
+++ b/services/anomaly_detection.py
@@ -625,7 +625,7 @@ class AnomalyDetectionService:
     def _build_context(self, period_id: Optional[str] = None) -> Dict[str, Any]:
         """Build analysis context from repositories."""
         # Get all vouchers (or filtered by period)
-        all_vouchers = self.voucher_repo.list_all()
+        all_vouchers, _ = self.voucher_repo.list_all()
         if period_id:
             vouchers = [v for v in all_vouchers if v.period_id == period_id]
         else:


### PR DESCRIPTION
## Problem
Sökfältet i verifikationslistan filtrerade bara bland de 15 vouchers som laddats för aktuell sida. En verifikation på sida 3 hittades inte vid sökning.

## Lösning

### Backend
- Lagt till `search`, `limit`, `offset` query-parametrar till `GET /api/v1/vouchers`
- `VoucherRepository.list_all()` returnerar nu `(vouchers, total_count)` tuple med SQL-filtrering på `description LIKE %search%` och verifikationsnummer
- Uppdaterat alla anropare av `list_all()` (reports.py, anomaly_detection.py)

### Frontend
- `api.getVouchers()` och `useVouchers()` skickar `search`-parametern till backend
- Sökfältet i `vouchers/page.tsx` triggar server-side fetch med 300ms debounce
- Sidan återställs till 1 när söktermen ändras
- Borttagen klient-side filtrering

### Ändrade filer
- `api/routes/vouchers.py` — nya query params
- `repositories/voucher_repo.py` — SQL-sökning + pagination
- `api/routes/reports.py` — anpassad till ny tuple-retur
- `services/anomaly_detection.py` — anpassad till ny tuple-retur
- `frontend-v3/lib/api.ts` — search param
- `frontend-v3/hooks/useData.ts` — search param
- `frontend-v3/app/vouchers/page.tsx` — debounce + server-side search

Closes #7