### PR TITLE
fix: 'Kör om analys' triggar faktisk omanalys (#8)

### DIFF
--- a/api/routes/anomalies.py
+++ b/api/routes/anomalies.py
@@ -110,6 +110,43 @@ async def check_voucher_anomalies(voucher_id: str):
         )
 
 
+@router.post("/scan", response_model=dict)
+async def trigger_anomaly_scan(
+    period_id: Optional[str] = Query(None, description="Filtrera på period-ID"),
+):
+    """
+    Kör en ny anomalianalys och returnerar en sammanfattning.
+    
+    Till skillnad från GET-endpointen som kan cacha resultat,
+    triggar denna endpoint alltid en fullständig omanalys.
+    """
+    try:
+        service = AnomalyDetectionService()
+        anomalies = service.analyze(period_id=period_id)
+        
+        from collections import defaultdict
+        by_type: dict[str, int] = defaultdict(int)
+        by_severity: dict[str, int] = defaultdict(int)
+        for a in anomalies:
+            by_type[a.anomaly_type.value] += 1
+            by_severity[a.severity.value] += 1
+        
+        return {
+            "total": len(anomalies),
+            "by_type": dict(by_type),
+            "by_severity": dict(by_severity),
+            "critical_count": by_severity.get("critical", 0),
+            "warning_count": by_severity.get("warning", 0),
+            "info_count": by_severity.get("info", 0),
+            "period_id": period_id,
+        }
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Anomalianalys misslyckades: {str(e)}",
+        )
+
+
 @router.get("/types", response_model=dict)
 async def list_anomaly_types():
     """

--- a/frontend-v3/app/anomalies/page.tsx
+++ b/frontend-v3/app/anomalies/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
 
 // ---- Types ----
 type Severity = "all" | "critical" | "warning" | "info";
@@ -244,6 +245,8 @@ function AnomalyRow({ anomaly }: { anomaly: any }) {
 export default function AnomaliesPage() {
   const [severity, setSeverity] = useState<Severity>("all");
   const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [isScanning, setIsScanning] = useState(false);
+  const [scanResult, setScanResult] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
   const { data: summary, isLoading: summaryLoading } = useAnomalySummary();
@@ -269,9 +272,23 @@ export default function AnomaliesPage() {
   // Available types from actual data
   const availableTypes = Array.from(new Set(allAnomalies.map((a) => a.type))).sort();
 
-  const handleRefresh = () => {
-    queryClient.invalidateQueries({ queryKey: ["anomalies"] });
-    queryClient.invalidateQueries({ queryKey: ["anomaly-summary"] });
+  const handleRefresh = async () => {
+    setIsScanning(true);
+    setScanResult(null);
+    try {
+      const result = await api.triggerAnomalyScan();
+      setScanResult(`Analys klar: ${result.total} anomalier hittade`);
+      // Invalidate cache to refresh the UI with fresh data
+      queryClient.invalidateQueries({ queryKey: ["anomalies"] });
+      queryClient.invalidateQueries({ queryKey: ["anomaly-summary"] });
+      // Clear result message after 5 seconds
+      setTimeout(() => setScanResult(null), 5000);
+    } catch (error) {
+      setScanResult("Analysen misslyckades. Försök igen.");
+      setTimeout(() => setScanResult(null), 5000);
+    } finally {
+      setIsScanning(false);
+    }
   };
 
   return (
@@ -284,10 +301,15 @@ export default function AnomaliesPage() {
             Automatisk granskning av bokföringen – misstänkta fel och avvikelser
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={handleRefresh} className="gap-2 flex-shrink-0">
-          <RefreshCw className="h-4 w-4" />
-          <span className="hidden sm:inline">Kör om analys</span>
-        </Button>
+        <div className="flex flex-col items-end gap-1 flex-shrink-0">
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isScanning} className="gap-2">
+            <RefreshCw className={`h-4 w-4 ${isScanning ? "animate-spin" : ""}`} />
+            <span className="hidden sm:inline">{isScanning ? "Analyserar…" : "Kör om analys"}</span>
+          </Button>
+          {scanResult && (
+            <p className="text-xs text-muted-foreground animate-in fade-in">{scanResult}</p>
+          )}
+        </div>
       </div>
 
       {/* Summary KPIs */}

--- a/frontend-v3/lib/api.ts
+++ b/frontend-v3/lib/api.ts
@@ -232,6 +232,10 @@ export const api = {
     });
     return data;
   },
+  triggerAnomalyScan: async () => {
+    const { data } = await apiClient.post("/api/v1/anomalies/scan");
+    return data;
+  },
 
   // Compliance
   getComplianceIssues: async () => {


### PR DESCRIPTION
## Problem
Knappen "Kör om analys" på `/anomalies`-sidan anropade bara `queryClient.invalidateQueries()` — rensar React Query-cachen och hämtar samma data. Ingen faktisk omanalys kördes.

## Lösning

### Backend
- Ny endpoint: `POST /api/v1/anomalies/scan`
- Kör `AnomalyDetectionService().analyze()` och returnerar sammanfattning (total, per typ, per severity)

### Frontend
- Ny funktion `triggerAnomalyScan()` i `lib/api.ts`
- Knappen "Kör om analys" anropar nu scan-endpointen
- Visar loading-spinner (animerad RefreshCw-ikon) under körning
- Visar resultat-meddelande (t.ex. "Analys klar: 495 anomalier hittade") i 5 sekunder
- Invaliderar cache efter scan för att uppdatera listan

Closes #8