### PR TITLE
feat: Separate system and company agent instructions (#34)

### DIFF
--- a/api/routes/agent_instructions.py
+++ b/api/routes/agent_instructions.py
@@ -1,4 +1,12 @@
-"""API routes for versioned Markdown agent instructions."""
+"""API routes for versioned Markdown agent instructions.
+
+This module provides endpoints for agent instructions with a clear separation
+between:
+- System instructions: Read-only, version-controlled documentation about how
+  the system works (SIE4 import, API behavior, etc.)
+- Company instructions: Writable instructions for company-specific rules and
+  learnings.
+"""
 
 from typing import Optional
 
@@ -7,6 +15,10 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_current_actor
 from repositories.agent_instruction_repo import AgentInstructionRepository
+from repositories.system_instructions import (
+    get_accounting_system_instructions,
+    get_invoicing_system_instructions,
+)
 
 router = APIRouter(prefix="/api/v1/agent-instructions", tags=["agent-instructions"])
 
@@ -18,18 +30,44 @@ class UpdateAgentInstructionRequest(BaseModel):
 
 @router.get("/accounting", response_model=dict)
 async def get_accounting_instructions(actor: str = Depends(get_current_actor)):
-    """Get the active Markdown instructions for the accounting agent."""
+    """Get both system and company instructions for the accounting agent.
+    
+    Returns:
+        - system: Read-only system instructions (how the system works)
+        - company: Writable company-specific instructions
+    """
     try:
-        return AgentInstructionRepository.get_active("accounting")
+        system_instructions = get_accounting_system_instructions()
+        company_instructions = AgentInstructionRepository.get_active("accounting_company")
+        
+        return {
+            "scope": "accounting",
+            "system": system_instructions,
+            "company": company_instructions,
+            "note": "Systeminstruktioner är skrivskyddade. Endast company-instruktioner kan uppdateras."
+        }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 
 
 @router.get("/invoicing", response_model=dict)
 async def get_invoicing_instructions(actor: str = Depends(get_current_actor)):
-    """Get the active Markdown instructions for the invoicing agent."""
+    """Get both system and company instructions for the invoicing agent.
+    
+    Returns:
+        - system: Read-only system instructions
+        - company: Writable company-specific instructions
+    """
     try:
-        return AgentInstructionRepository.get_active("invoicing")
+        system_instructions = get_invoicing_system_instructions()
+        company_instructions = AgentInstructionRepository.get_active("invoicing_company")
+        
+        return {
+            "scope": "invoicing",
+            "system": system_instructions,
+            "company": company_instructions,
+            "note": "Systeminstruktioner är skrivskyddade. Endast company-instruktioner kan uppdateras."
+        }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 
@@ -39,10 +77,14 @@ async def update_accounting_instructions(
     request: UpdateAgentInstructionRequest,
     actor: str = Depends(get_current_actor),
 ):
-    """Create a new active version of the accounting agent instructions."""
+    """Update company-specific accounting instructions.
+    
+    System instructions cannot be modified through this endpoint.
+    Only company-specific rules and learnings should be updated here.
+    """
     try:
         return AgentInstructionRepository.update(
-            scope="accounting",
+            scope="accounting_company",
             content_markdown=request.content_markdown,
             change_summary=request.change_summary,
             created_by=actor,
@@ -56,10 +98,14 @@ async def update_invoicing_instructions(
     request: UpdateAgentInstructionRequest,
     actor: str = Depends(get_current_actor),
 ):
-    """Create a new active version of the invoicing agent instructions."""
+    """Update company-specific invoicing instructions.
+    
+    System instructions cannot be modified through this endpoint.
+    Only company-specific rules and learnings should be updated here.
+    """
     try:
         return AgentInstructionRepository.update(
-            scope="invoicing",
+            scope="invoicing_company",
             content_markdown=request.content_markdown,
             change_summary=request.change_summary,
             created_by=actor,
@@ -70,19 +116,93 @@ async def update_invoicing_instructions(
 
 @router.get("/accounting/versions", response_model=dict)
 async def list_accounting_instruction_versions(actor: str = Depends(get_current_actor)):
-    """List accounting instruction versions, newest first."""
+    """List company instruction versions, newest first.
+    
+    System instructions are version-controlled in Git and not listed here.
+    """
     try:
-        versions = AgentInstructionRepository.list_versions("accounting")
-        return {"scope": "accounting", "total": len(versions), "versions": versions}
+        versions = AgentInstructionRepository.list_versions("accounting_company")
+        return {
+            "scope": "accounting_company",
+            "total": len(versions),
+            "versions": versions,
+            "note": "Visar endast versionshistorik för company-instruktioner. Systeminstruktioner versionshanteras i Git."
+        }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 
 
 @router.get("/invoicing/versions", response_model=dict)
 async def list_invoicing_instruction_versions(actor: str = Depends(get_current_actor)):
-    """List invoicing instruction versions, newest first."""
+    """List company instruction versions, newest first.
+    
+    System instructions are version-controlled in Git and not listed here.
+    """
     try:
-        versions = AgentInstructionRepository.list_versions("invoicing")
-        return {"scope": "invoicing", "total": len(versions), "versions": versions}
+        versions = AgentInstructionRepository.list_versions("invoicing_company")
+        return {
+            "scope": "invoicing_company",
+            "total": len(versions),
+            "versions": versions,
+            "note": "Visar endast versionshistorik för company-instruktioner. Systeminstruktioner versionshanteras i Git."
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/system/accounting", response_model=dict)
+async def get_accounting_system_instructions_only(
+    actor: str = Depends(get_current_actor)
+):
+    """Get only the system instructions for accounting.
+    
+    These are read-only and describe how the system works.
+    """
+    try:
+        return get_accounting_system_instructions()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/system/invoicing", response_model=dict)
+async def get_invoicing_system_instructions_only(
+    actor: str = Depends(get_current_actor)
+):
+    """Get only the system instructions for invoicing.
+    
+    These are read-only and describe how the system works.
+    """
+    try:
+        return get_invoicing_system_instructions()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# Legacy endpoints for backward compatibility
+@router.get("/accounting/legacy", response_model=dict)
+async def get_accounting_instructions_legacy(
+    actor: str = Depends(get_current_actor)
+):
+    """Legacy endpoint: Get combined instructions (deprecated).
+    
+    This endpoint returns the old combined format for backward compatibility.
+    New integrations should use GET /accounting which separates system and company.
+    """
+    try:
+        # Get company instructions (which may have been updated from legacy data)
+        company = AgentInstructionRepository.get_active("accounting")
+        
+        return {
+            "scope": "accounting",
+            "version_id": company.get("version_id"),
+            "version": company.get("version"),
+            "content_markdown": company.get("content_markdown"),
+            "change_summary": company.get("change_summary"),
+            "created_by": company.get("created_by"),
+            "created_at": company.get("created_at"),
+            "updated_at": company.get("updated_at"),
+            "deprecated": True,
+            "note": "Detta är ett legacy-endpoint. Använd GET /accounting för separerade system/company-instruktioner."
+        }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/docs/to_agent/04_sie4_import_och_rakenskapsar.md
+++ b/docs/to_agent/04_sie4_import_och_rakenskapsar.md
@@ -1,0 +1,127 @@
+# SIE4-import och räkenskapsår
+
+Detta dokument beskriver hur systemet hanterar import av SIE4-filer och
+räkenskapsår. Informationen är systemkritisk och används för att förstå hur
+verifikationer placeras vid import.
+
+## SIE4-formatet
+
+SIE4 (Standardiserad Import/Export) är ett svenskt filformat för
+redovisningsdata. Varje fil innehåller transaktioner för ett specifikt
+räkenskapsår.
+
+## Räkenskapsårsidentifiering (`#RAR`)
+
+SIE4-filer använder taggen `#RAR` för att ange räkenskapsår:
+
+```
+#RAR <årindex> <startdatum> <slutdatum>
+```
+
+Exempel:
+```
+#RAR 0 20250101 20251231    ; Aktuellt räkenskapsår 2025
+#RAR -1 20240101 20241231   ; Föregående räkenskapsår 2024
+```
+
+- `#RAR 0` anger filens aktuella räkenskapsår.
+- Systemet tolkar datum för att placera verifikationer i rätt period.
+- Verifikationer placeras i period baserat på verifikationsdatum inom rätt
+  räkenskapsår.
+
+## Ingående balans (`#IB`)
+
+Taggen `#IB` anger ingående balans för konton:
+
+```
+#IB <årindex> <kontonummer> <belopp>
+```
+
+- `#IB 0` = Ingående balans för filens aktuella räkenskapsår.
+- Systemet kan skapa en IB-verifikation baserat på dessa värden.
+- Beloppen måste balansera (debet = kredit) för att vara giltiga.
+
+Exempel från verklig data:
+```
+#IB 0 1920 166166177        ; Ingående balans konto 1920: 1 661 661,77 kr
+```
+
+## Utgående balans (`#UB`)
+
+Taggen `#UB` anger utgående balans:
+
+```
+#UB <årindex> <kontonummer> <belopp>
+```
+
+- `#UB -1` = Ingående balans för aktuellt år (föregående års ingående).
+- `#UB 0` = Utgående balans för filens räkenskapsår.
+
+**Viktigt:** Föregående års utgående balans (`#UB 0` för år N) blir nästa års
+ingående balans (`#IB 0` för år N+1).
+
+Systemet importerar normalt inte `#UB`-värden som verifikationer, men de är
+viktiga för att förstå sambandet mellan år.
+
+## Multi-period import
+
+Systemet stödjer import av flera SIE4-filer med olika räkenskapsår:
+
+1. Varje fil behandlas separat baserat på sin `#RAR`-tagg.
+2. Verifikationer placeras i rätt period baserat på verifikationsdatum.
+3. Verifikationsnummer fortsätter i serie inom varje räkenskapsår.
+
+### Exempel från produktionsdata
+
+**SIE4 2025** (155 verifikationer: A1-A155):
+```
+#RAR 0 20250101 20251231
+#UB -1 1920 166166177       ; IB 2025 = 1 661 661,77 kr
+#UB 0 1920 119113902        ; UB 2025 = 1 191 139,02 kr
+                              ; Skillnad = -470 522 kr (resultatet för 2025)
+```
+
+**SIE4 2026** (31 verifikationer: A156-A186):
+```
+#RAR 0 20260101 20261231
+#IB 0 1920 119113902        ; IB 2026 = samma som UB 2025
+```
+
+Verifikationerna fortsätter i A-serien från föregående import.
+
+## IB-verifikationer vid import
+
+Vid import kan systemet skapa IB-verifikationer automatiskt:
+
+- Format: `A<år>` där `<år>` är räkenskapsåret (t.ex. A190 för IB 2025).
+- Belopp måste balansera exakt: D = K.
+- Endast konton med saldo > 0 inkluderas.
+
+## Viktiga principer
+
+1. **Datum är avgörande:** Verifikationer placeras alltid i den period som
+   motsvarar verifikationsdatumet.
+2. **Räkenskapsår från `#RAR`:** Filens `#RAR 0` bestämmer vilket räkenskapsår
+   verifikationerna tillhör.
+3. **Seriefortsättning:** Verifikationsnummer fortsätter automatiskt när flera
+   filer importeras för samma räkenskapsår.
+4. **Inga dubbletter:** Systemet hanterar import så att samma verifikation inte
+   skapas flera gånger.
+
+## Filhantering
+
+SIE4-filer kan innehålla:
+- Verifikationer med fullständiga konteringsrader
+- Ingående balanser (`#IB`)
+- Utgående balanser (`#UB`)
+- Kontoplan (`#KONTO`)
+- Dimensionsinformation (`#DIM`, `#OBJ`)
+
+Systemet importerar främst verifikationer och balanser. Kontoplan och
+dimensioner används som referens vid import men påverkar inte systemets egen
+kontoplan.
+
+## Källa
+
+- SIE4-standard: https://www.sie.se/
+- BAS-kontoplanen: https://www.bas.se/

--- a/repositories/system_instructions.py
+++ b/repositories/system_instructions.py
@@ -1,0 +1,93 @@
+"""Read-only system instructions for agents.
+
+System instructions contain critical, stable documentation about how the system
+works (SIE4 import, API behavior, accounting principles). These are read from
+version-controlled files and cannot be modified by agents.
+
+Company-specific instructions are stored separately and can be updated by agents.
+"""
+
+import os
+from typing import Dict, List, Optional
+
+# Base directory for system instruction documents
+DOCS_TO_AGENT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "docs", "to_agent"
+)
+
+# Ordered list of system instruction files
+# These are read-only and contain system-critical information
+SYSTEM_INSTRUCTION_FILES: List[tuple] = [
+    ("01_drift_och_atkomst.md", "Drift och åtkomst"),
+    ("02_bokforingsprocess.md", "Bokföringsprocess"),
+    ("03_bokforingsinstruktion.md", "Bokföringsinstruktion"),
+    ("04_sie4_import_och_rakenskapsar.md", "SIE4-import och räkenskapsår"),
+]
+
+
+def get_system_instructions() -> Dict:
+    """Return all system instructions as a combined document.
+    
+    These instructions are read-only and contain system-critical information
+    that agents should not be able to modify.
+    """
+    sections = []
+    
+    for filename, title in SYSTEM_INSTRUCTION_FILES:
+        filepath = os.path.join(DOCS_TO_AGENT_DIR, filename)
+        content = _read_file(filepath)
+        if content:
+            sections.append(f"# {title}\n\n{content}")
+    
+    combined_content = "\n\n---\n\n".join(sections)
+    
+    return {
+        "scope": "system",
+        "content_markdown": combined_content,
+        "source": "version_controlled_files",
+        "files": [f[0] for f in SYSTEM_INSTRUCTION_FILES],
+        "is_editable": False,
+        "description": "Systeminstruktioner är skrivskyddade och innehåller kritisk information om hur systemet fungerar."
+    }
+
+
+def get_accounting_system_instructions() -> Dict:
+    """Return system instructions specifically for accounting agent."""
+    return get_system_instructions()
+
+
+def get_invoicing_system_instructions() -> Dict:
+    """Return system instructions specifically for invoicing agent.
+    
+    Currently returns the same as accounting, but can be customized.
+    """
+    # For now, invoicing uses a subset or the same system instructions
+    # In the future, this could load different files
+    return get_system_instructions()
+
+
+def _read_file(filepath: str) -> Optional[str]:
+    """Read a file and return its contents, or None if not found."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        return f"[Fel vid läsning av fil: {str(e)}]"
+
+
+def list_available_files() -> List[Dict]:
+    """List all available system instruction files with their status."""
+    result = []
+    for filename, title in SYSTEM_INSTRUCTION_FILES:
+        filepath = os.path.join(DOCS_TO_AGENT_DIR, filename)
+        exists = os.path.exists(filepath)
+        result.append({
+            "filename": filename,
+            "title": title,
+            "exists": exists,
+            "path": filepath if exists else None
+        })
+    return result

--- a/tests/test_agent_instructions_separation.py
+++ b/tests/test_agent_instructions_separation.py
@@ -1,0 +1,227 @@
+"""Tests for separated system and company agent instructions.
+
+This test suite verifies:
+1. System instructions are read-only and loaded from files
+2. Company instructions can be updated via API
+3. API returns both system and company instructions separately
+4. Legacy endpoints still work for backward compatibility
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from repositories.system_instructions import (
+    get_system_instructions,
+    get_accounting_system_instructions,
+    list_available_files,
+)
+
+
+client = TestClient(app)
+
+
+class TestSystemInstructions:
+    """Test system instructions loader."""
+
+    def test_get_system_instructions_returns_structure(self):
+        """System instructions should return proper structure."""
+        result = get_system_instructions()
+        
+        assert result["scope"] == "system"
+        assert result["is_editable"] is False
+        assert "content_markdown" in result
+        assert "source" in result
+        assert "files" in result
+        assert "description" in result
+    
+    def test_get_accounting_system_instructions(self):
+        """Accounting system instructions should include all docs."""
+        result = get_accounting_system_instructions()
+        
+        assert result["scope"] == "system"
+        assert "drift_och_atkomst" in result["content_markdown"].lower() or \
+               "miljö" in result["content_markdown"].lower()
+        assert "bokföringsprocess" in result["content_markdown"].lower() or \
+               "verifikation" in result["content_markdown"].lower()
+        assert "sie4" in result["content_markdown"].lower() or \
+               "import" in result["content_markdown"].lower()
+    
+    def test_list_available_files(self):
+        """Should list all expected files."""
+        files = list_available_files()
+        
+        assert len(files) >= 4
+        
+        filenames = [f["filename"] for f in files]
+        assert "01_drift_och_atkomst.md" in filenames
+        assert "02_bokforingsprocess.md" in filenames
+        assert "03_bokforingsinstruktion.md" in filenames
+        assert "04_sie4_import_och_rakenskapsar.md" in filenames
+        
+        # All files should exist
+        for f in files:
+            assert f["exists"] is True, f"File {f['filename']} should exist"
+
+
+class TestAgentInstructionsAPI:
+    """Test agent instructions API endpoints."""
+
+    def test_get_accounting_instructions_structure(self, auth_headers):
+        """GET /accounting should return both system and company."""
+        response = client.get(
+            "/api/v1/agent-instructions/accounting",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["scope"] == "accounting"
+        assert "system" in data
+        assert "company" in data
+        assert "note" in data
+        
+        # System should be read-only
+        assert data["system"]["is_editable"] is False
+        assert data["system"]["scope"] == "system"
+        
+        # Company should have version info
+        assert "version" in data["company"]
+        assert "content_markdown" in data["company"]
+    
+    def test_get_invoicing_instructions_structure(self, auth_headers):
+        """GET /invoicing should return both system and company."""
+        response = client.get(
+            "/api/v1/agent-instructions/invoicing",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["scope"] == "invoicing"
+        assert "system" in data
+        assert "company" in data
+    
+    def test_update_accounting_company_instructions(self, auth_headers):
+        """PUT /accounting should update company instructions."""
+        new_content = "# Företagsspecifika instruktioner\n\nVi använder konto 1930 istället för 1920."
+        
+        response = client.put(
+            "/api/v1/agent-instructions/accounting",
+            headers=auth_headers,
+            json={
+                "content_markdown": new_content,
+                "change_summary": "Uppdaterat bankkontonummer"
+            }
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["scope"] == "accounting_company"
+        assert data["content_markdown"] == new_content
+        assert data["change_summary"] == "Uppdaterat bankkontonummer"
+        assert "version" in data
+        assert "version_id" in data
+    
+    def test_update_invoicing_company_instructions(self, auth_headers):
+        """PUT /invoicing should update company instructions."""
+        new_content = "# Faktureringsregler\n\nAlla fakturor ska ha ordernummer."
+        
+        response = client.put(
+            "/api/v1/agent-instructions/invoicing",
+            headers=auth_headers,
+            json={
+                "content_markdown": new_content,
+                "change_summary": "Lagt till ordernummerkrav"
+            }
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["scope"] == "invoicing_company"
+        assert "version" in data
+    
+    def test_accounting_versions_endpoint(self, auth_headers):
+        """GET /accounting/versions should list company versions."""
+        response = client.get(
+            "/api/v1/agent-instructions/accounting/versions",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["scope"] == "accounting_company"
+        assert "versions" in data
+        assert "total" in data
+        assert "note" in data
+    
+    def test_system_only_endpoints(self, auth_headers):
+        """System-only endpoints should return read-only instructions."""
+        response = client.get(
+            "/api/v1/agent-instructions/system/accounting",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["is_editable"] is False
+        assert data["scope"] == "system"
+        assert "SIE4" in data["content_markdown"] or "import" in data["content_markdown"].lower()
+
+
+class TestSIE4Documentation:
+    """Test that SIE4 documentation is properly included."""
+
+    def test_sie4_documentation_in_system_instructions(self):
+        """SIE4 documentation should be part of system instructions."""
+        result = get_system_instructions()
+        content = result["content_markdown"]
+        
+        # Should contain key SIE4 concepts
+        assert "SIE4" in content
+        assert "#RAR" in content
+        assert "#IB" in content
+        assert "#UB" in content
+        assert "räkenskapsår" in content.lower()
+        assert "multi-period" in content.lower() or "multiperiod" in content.lower()
+    
+    def test_sie4_documentation_via_api(self, auth_headers):
+        """SIE4 documentation should be accessible via API."""
+        response = client.get(
+            "/api/v1/agent-instructions/system/accounting",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        content = data["content_markdown"]
+        assert "SIE4" in content
+        assert "#RAR" in content
+        assert "ingående balans" in content.lower() or "IB" in content
+
+
+class TestBackwardCompatibility:
+    """Test that legacy endpoints still work."""
+
+    def test_legacy_accounting_endpoint(self, auth_headers):
+        """Legacy endpoint should still work."""
+        response = client.get(
+            "/api/v1/agent-instructions/accounting/legacy",
+            headers=auth_headers
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should have old format
+        assert "content_markdown" in data
+        assert "version" in data
+        assert data.get("deprecated") is True
+        assert "note" in data


### PR DESCRIPTION
Implements the approved plan from issue #34.

## Changes

### 1. SIE4 Import Documentation
- Added "docs/to_agent/04_sie4_import_och_rakenskapsar.md"
- Documents #RAR, #IB, #UB tags and fiscal year handling
- Explains multi-period import logic with production examples

### 2. Read-Only System Instructions
- Created "repositories/system_instructions.py"
- Loads from version-controlled files in docs/to_agent/
- Cannot be modified by agents
- Contains critical system documentation

### 3. Updated API
- GET /accounting now returns both system and company separately
- PUT /accounting updates only company instructions
- New endpoints: /system/accounting for read-only access
- Legacy endpoint preserved for backward compatibility

### 4. Tests
- Added comprehensive test suite
- Tests for system instructions loader
- Tests for API endpoints
- Tests for SIE4 documentation inclusion
- Tests for backward compatibility

## Migration Notes
- Existing accounting instructions remain accessible via legacy endpoint
- Company instructions start fresh with default content
- System instructions are now read-only from version-controlled files

Closes #34